### PR TITLE
Grab UTF-8 string instead of ambiguous string

### DIFF
--- a/source/plugin.cpp
+++ b/source/plugin.cpp
@@ -101,8 +101,8 @@ own3d::configuration::configuration()
 		_data = std::shared_ptr<obs_data_t>(obs_data_create(), ::own3d::data_deleter);
 	} else {
 		if (std::filesystem::exists(_data_path)) {
-			_data = std::shared_ptr<obs_data_t>(obs_data_create_from_json_file_safe(_data_path.string().c_str(), ".bk"),
-												::own3d::data_deleter);
+			_data = std::shared_ptr<obs_data_t>(
+				obs_data_create_from_json_file_safe(_data_path.u8string().c_str(), ".bk"), ::own3d::data_deleter);
 		} else {
 			_data = std::shared_ptr<obs_data_t>(obs_data_create(), ::own3d::data_deleter);
 		}
@@ -117,7 +117,7 @@ std::shared_ptr<obs_data_t> own3d::configuration::get()
 
 void own3d::configuration::save()
 {
-	obs_data_save_json_safe(_data.get(), _data_path.string().c_str(), ".tmp", ".bk");
+	obs_data_save_json_safe(_data.get(), _data_path.u8string().c_str(), ".tmp", ".bk");
 }
 
 std::shared_ptr<own3d::configuration> own3d::configuration::_instance = nullptr;

--- a/source/ui/ui-download.cpp
+++ b/source/ui/ui-download.cpp
@@ -312,12 +312,12 @@ void own3d::ui::installer_thread::run_install()
 			throw std::runtime_error("Unable to install, missing data.json file.");
 		}
 
-		data.reset(obs_data_create_from_json_file(data_path.string().c_str()), own3d::data_deleter);
+		data.reset(obs_data_create_from_json_file(data_path.u8string().c_str()), own3d::data_deleter);
 		if (!data) {
 			throw std::runtime_error("Failed to install theme, data.json may be corrupted.");
 		}
 
-		adjust_collection(data, name, std::filesystem::absolute(_out_path).string());
+		adjust_collection(data, name, std::filesystem::absolute(_out_path).u8string());
 	}
 
 	// Step 3: Store current scene collection, and create new temporary one.
@@ -329,7 +329,7 @@ void own3d::ui::installer_thread::run_install()
 	}
 
 	// Step 4: Save JSON as new file.
-	if (!obs_data_save_json_safe(data.get(), file_path.string().c_str(), ".tmp", ".bk")) {
+	if (!obs_data_save_json_safe(data.get(), file_path.u8string().c_str(), ".tmp", ".bk")) {
 		throw std::runtime_error("Failed to install theme, unable to write output file.");
 	}
 

--- a/source/util/zip.cpp
+++ b/source/util/zip.cpp
@@ -27,9 +27,9 @@ own3d::util::zip::zip(std::filesystem::path path, std::filesystem::path output_p
 	: _file_path(path), _out_path(output_path)
 {
 	int32_t error = 0;
-	_archive      = zip_open(_file_path.string().c_str(), ZIP_CHECKCONS | ZIP_RDONLY, &error);
+	_archive      = zip_open(_file_path.u8string().c_str(), ZIP_CHECKCONS | ZIP_RDONLY, &error);
 	if (error != 0) {
-		DLOG_ERROR("Unzipping file '%s' failed with error code %ld.", _file_path.string().c_str(), error);
+		DLOG_ERROR("Unzipping file '%s' failed with error code %ld.", _file_path.u8string().c_str(), error);
 		throw std::runtime_error("Failed to read zip file.");
 	}
 }
@@ -44,7 +44,7 @@ void own3d::util::zip::extract_file(uint64_t idx, std::function<void(uint64_t, u
 	std::shared_ptr<zip_file_t> file = std::shared_ptr<zip_file_t>(zip_fopen_index(_archive, idx, ZIP_FL_UNCHANGED),
 																   [](zip_file_t* v) { zip_fclose(v); });
 	if (!file) {
-		DLOG_ERROR("Failed to extract file index %lld from archive '%s'.", idx, _file_path.string().c_str());
+		DLOG_ERROR("Failed to extract file index %lld from archive '%s'.", idx, _file_path.u8string().c_str());
 		throw std::runtime_error("Failed to extract file from archive.");
 	}
 
@@ -66,7 +66,7 @@ void own3d::util::zip::extract_file(uint64_t idx, std::function<void(uint64_t, u
 	if (stat.size > 0) {
 		std::ofstream stream{filepath, std::ios::binary | std::ios::trunc | std::ios::out};
 		if (stream.bad()) {
-			DLOG_ERROR("Failed to extract file '%s' from archive '%s'.", stat.name, _file_path.string().c_str());
+			DLOG_ERROR("Failed to extract file '%s' from archive '%s'.", stat.name, _file_path.u8string().c_str());
 			throw std::runtime_error("Failed to extract file.");
 		}
 		std::vector<char> buffer;


### PR DESCRIPTION
Explicitly retrieves a UTF-8 string instead of trusting the C++ runtime to do it for us when calling .string().